### PR TITLE
Remove dependency for release creation

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -61,9 +61,6 @@ jobs:
           cache-to: type=inline
 
       - name: Create GitHub pre-release
-        uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0
-        with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: v${{ env.VERSION }}
-          prerelease: true
-          title: ${{ env.VERSION }}
+        run: gh release create --generate-notes --title v${{ env.VERSION }} --prerelease
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Resolves: #7 
https://cli.github.com/manual/gh_release_create

Soweit ich das sehe, können wir das ganze nur auf `main` korrekt testen.